### PR TITLE
Update parse.py for better code and testing

### DIFF
--- a/bindings/python/scripts/context.py
+++ b/bindings/python/scripts/context.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import scripts

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -249,7 +249,7 @@ def main():
             source=source,
             output_dir=utils.join_path(args.json_output_path, "json"),
             split_from="pcl",
-            extension="json",
+            extension=".json",
         )
 
         # Dump the parsed info at output path

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -14,7 +14,11 @@ def is_node_in_this_file(cursor, filename):
 def print_ast(cursor, this_filename, depth):
     if cursor.spelling:
         print(
-            "-" * depth, cursor.location.file, f"L{cursor.location.line} C{cursor.location.column}", cursor.kind.name, cursor.spelling,
+            "-" * depth,
+            cursor.location.file,
+            f"L{cursor.location.line} C{cursor.location.column}",
+            cursor.kind.name,
+            cursor.spelling,
         )
 
     for child in cursor.get_children():
@@ -45,7 +49,9 @@ def generate_parsed_info(cursor, this_filename, depth):
 
     for child in cursor.get_children():
         if is_node_in_this_file(cursor=child, filename=this_filename):
-            child_parsed_info = generate_parsed_info(cursor=child, this_filename=this_filename, depth=depth + 1,)
+            child_parsed_info = generate_parsed_info(
+                cursor=child, this_filename=this_filename, depth=depth + 1,
+            )
             if child_parsed_info and parsed_info:
                 parsed_info["members"].append(child_parsed_info)
 
@@ -57,7 +63,9 @@ def create_index():
 
 
 def get_compilation_commands(compilation_database_path, filename):
-    compilation_database = clang.CompilationDatabase.fromDirectory(buildDir=compilation_database_path)
+    compilation_database = clang.CompilationDatabase.fromDirectory(
+        buildDir=compilation_database_path
+    )
     compilation_commands = compilation_database.getCompileCommands(filename=filename)
     # extracting argument list from the command's generator object
     return list(compilation_commands[0].arguments)[1:-1]
@@ -71,16 +79,22 @@ def main():
         index = create_index()
 
         compilation_commands = get_compilation_commands(
-            compilation_database_path="/home/divyanshu/Projects/active/pcl/bindings/python", filename=source
+            compilation_database_path="/home/divyanshu/Projects/active/pcl/bindings/python",
+            filename=source,
         )
 
         tu = index.parse(path=source, args=compilation_commands)
 
         # print_ast(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
 
-        parsed_info = generate_parsed_info(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
+        parsed_info = generate_parsed_info(
+            cursor=tu.cursor, this_filename=tu.spelling, depth=0
+        )
 
-        output_filepath = utils.get_json_output_path(source=source, output_dir="/home/divyanshu/Projects/active/pcl/bindings/python/json",)
+        output_filepath = utils.get_json_output_path(
+            source=source,
+            output_dir="/home/divyanshu/Projects/active/pcl/bindings/python/json",
+        )
         utils.dump_json(filepath=output_filepath, info=parsed_info)
 
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -79,7 +79,7 @@ def main():
 
         parsed_info = generate_parsed_info(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
 
-        output_filepath = utils.get_json_output_path(source=source, output_dir="../json")
+        output_filepath = utils.get_json_output_path(source=source, output_dir="/home/divyanshu/Projects/active/pcl/bindings/python/json",)
         utils.dump_json(filepath=output_filepath, info=parsed_info)
 
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -116,7 +116,7 @@ def get_compilation_commands(compilation_database_path, filename):
 
 
 def main():
-    args = utils.parse_arguments(args=sys.argv[1:], script="parse")
+    args = utils.parse_arguments(script="parse")
     for source in args.files:
         source = utils.get_realpath(path=source)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -190,8 +190,11 @@ def main():
         parsed_info = parse_file(source, args.compilation_database_path)
 
         # Output path for dumping the parsed info into a json file
-        output_filepath = utils.get_json_output_path(
-            source=source, output_dir=utils.join_path(args.json_output_path, "json"),
+        output_filepath = utils.get_output_path(
+            source=source,
+            output_dir=utils.join_path(args.json_output_path, "json"),
+            split_from="pcl",
+            extension="json",
         )
 
         # Dump the parsed info at output path

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -4,24 +4,22 @@ import clang.cindex as clang
 import utils
 
 
-def print_node(cursor, depth):
-    print("-" * depth, cursor.location.file, f"L{cursor.location.line} C{cursor.location.column}", cursor.kind.name, cursor.spelling)
-
-
-def is_node_in_this_file(node, filename):
-    if node.location.file and node.location.file.name == filename:
+def is_node_in_this_file(cursor, filename):
+    if cursor.location.file and cursor.location.file.name == filename:
         return True
     else:
         return False
 
 
-def walk_and_print(cursor, this_filename, depth):
+def print_ast(cursor, this_filename, depth):
     if cursor.spelling:
-        print_node(cursor=cursor, depth=depth)
+        print(
+            "-" * depth, cursor.location.file, f"L{cursor.location.line} C{cursor.location.column}", cursor.kind.name, cursor.spelling,
+        )
 
     for child in cursor.get_children():
-        if is_node_in_this_file(node=child, filename=this_filename):
-            walk_and_print(cursor=child, this_filename=this_filename, depth=depth + 1)
+        if is_node_in_this_file(cursor=child, filename=this_filename):
+            print_ast(cursor=child, this_filename=this_filename, depth=depth + 1)
 
 
 def generate_parsed_info(cursor, this_filename, depth):
@@ -46,7 +44,7 @@ def generate_parsed_info(cursor, this_filename, depth):
         parsed_info["members"] = []
 
     for child in cursor.get_children():
-        if is_node_in_this_file(node=child, filename=this_filename):
+        if is_node_in_this_file(cursor=child, filename=this_filename):
             child_parsed_info = generate_parsed_info(cursor=child, this_filename=this_filename, depth=depth + 1,)
             if child_parsed_info and parsed_info:
                 parsed_info["members"].append(child_parsed_info)
@@ -78,7 +76,7 @@ def main():
 
         tu = index.parse(path=source, args=compilation_commands)
 
-        # walk_and_print(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
+        # print_ast(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
 
         parsed_info = generate_parsed_info(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -63,7 +63,7 @@ def get_compilation_commands(compilation_database_path, filename):
 
 
 def main():
-    args = utils.parse_arguments(args=sys.argv[1:], script=__file__)
+    args = utils.parse_arguments(args=sys.argv[1:], script="parse")
     for source in args.files:
         source = utils.get_realpath(path=source)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -55,14 +55,14 @@ def create_index():
     return clang.Index.create()
 
 
-def get_compilation_database(compile_db_path):
-    return clang.CompilationDatabase.fromDirectory(buildDir=compile_db_path)
+def get_compilation_database(compilation_database_path):
+    return clang.CompilationDatabase.fromDirectory(buildDir=compilation_database_path)
 
 
-def get_compile_commands(compdb, filename):
-    compile_commands = compdb.getCompileCommands(filename=filename)
+def get_compilation_commands(compilation_database, filename):
+    compilation_commands = compilation_database.getCompileCommands(filename=filename)
     # extracting argument list from the command's generator object
-    return list(compile_commands[0].arguments)[1:-1]
+    return list(compilation_commands[0].arguments)[1:-1]
 
 
 def main():
@@ -72,11 +72,11 @@ def main():
 
         index = create_index()
 
-        compile_db_path = utils.get_dirname(path="../compile_commands.json")
-        compdb = get_compilation_database(compile_db_path=compile_db_path)
-        compile_commands = get_compile_commands(compdb=compdb, filename=source)
+        compilation_database_path = utils.get_dirname(path="../compile_commands.json")
+        compilation_database = get_compilation_database(compilation_database_path=compilation_database_path)
+        compilation_commands = get_compilation_commands(compilation_database=compilation_database, filename=source)
 
-        tu = index.parse(path=source, args=compile_commands)
+        tu = index.parse(path=source, args=compilation_commands)
 
         # walk_and_print(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -5,6 +5,17 @@ import utils
 
 
 def is_node_in_this_file(cursor, filename):
+    """
+    Checks if the node in the AST belongs to the file
+    
+    Arguments:
+        - cursor : The cursor pointing to the node
+        - filename : The file's name to check the node against
+        
+    Returns:
+        - True/False (bool)
+    """
+
     if cursor.location.file and cursor.location.file.name == filename:
         return True
     else:
@@ -12,6 +23,18 @@ def is_node_in_this_file(cursor, filename):
 
 
 def print_ast(cursor, this_filename, depth):
+    """
+    Prints the AST by recursively traversing the AST
+
+    Arguments:
+        - cursor: The cursor pointing to a node
+        - this_filename: The file's name to check if the node belongs to it
+        - depth: The depth of the node (root=0)
+    
+    Returns:
+        - None
+    """
+
     if cursor.spelling:
         print(
             "-" * depth,
@@ -27,6 +50,20 @@ def print_ast(cursor, this_filename, depth):
 
 
 def generate_parsed_info(cursor, this_filename, depth):
+    """
+    Generates parsed information by recursively traversing the AST
+
+    Arguments:
+        - cursor: The cursor pointing to a node
+        - this_filename: The file's name to check if the node belongs to it
+        - depth: The depth of the node (root=0)
+
+    Returns:
+        - parsed_info (dict): 
+            - Contains key-value pairs of various traits of a node
+            - The key 'members' contains the node's children's `parsed_info`
+    """
+
     parsed_info = dict()
 
     if cursor.spelling:
@@ -59,6 +96,17 @@ def generate_parsed_info(cursor, this_filename, depth):
 
 
 def get_compilation_commands(compilation_database_path, filename):
+    """
+    Returns the compilation commands extracted from the the compile command
+
+    Arguments:
+        - compilation_database_path: The path to `compile_commands.json`
+        - filename: The file's name to get it's compilation commands
+
+    Returns:
+        - compilation commands (list): The arguments passed to the compiler
+    """
+
     compilation_database = clang.CompilationDatabase.fromDirectory(
         buildDir=compilation_database_path
     )

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -116,7 +116,7 @@ def get_compilation_commands(compilation_database_path, filename):
     return list(compilation_commands[0].arguments)[1:-1]
 
 
-def parse_source(source, compilation_database_path=None):
+def parse_file(source, compilation_database_path=None):
     index = clang.Index.create()
 
     # Is this check needed?
@@ -147,7 +147,7 @@ def main():
     for source in args.files:
         source = utils.get_realpath(path=source)
 
-        parsed_info = parse_source(source, args.compilation_database_path)
+        parsed_info = parse_file(source, args.compilation_database_path)
 
         output_filepath = utils.get_json_output_path(
             source=source, output_dir=utils.join_path(args.json_output_path, "json"),

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -123,8 +123,7 @@ def main():
         index = clang.Index.create()
 
         compilation_commands = get_compilation_commands(
-            compilation_database_path="/home/divyanshu/Projects/active/pcl/bindings/python",
-            filename=source,
+            compilation_database_path=args.compilation_database_path, filename=source,
         )
 
         tu = index.parse(path=source, args=compilation_commands)
@@ -136,8 +135,7 @@ def main():
         )
 
         output_filepath = utils.get_json_output_path(
-            source=source,
-            output_dir="/home/divyanshu/Projects/active/pcl/bindings/python/json",
+            source=source, output_dir=f"{args.json_output_path}/json",
         )
         utils.dump_json(filepath=output_filepath, info=parsed_info)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -135,7 +135,7 @@ def main():
         )
 
         output_filepath = utils.get_json_output_path(
-            source=source, output_dir=f"{args.json_output_path}/json",
+            source=source, output_dir=utils.join_path(args.json_output_path, "json"),
         )
         utils.dump_json(filepath=output_filepath, info=parsed_info)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -5,20 +5,26 @@ from context import scripts
 import scripts.utils as utils
 
 
-def is_node_in_this_file(cursor, filename, depth):
+def is_node_in_this_file(node):
     """
     Checks if the node in the AST is a valid node:
         - Check 1: The cursor's location should have file attribute (cursor.location.file -> not NoneType)
         - Check 2: The cursor should belong to the file (cursor.location.file.name -> filename)
     
     Arguments:
-        - cursor : The cursor pointing to the node
-        - filename : The file's name to check the node against
-        - depth: The depth of the node (root=0)
+        - node (dict):
+            - The node in the AST
+            - Keys:
+                - cursor : The cursor pointing to the node
+                - filename : The file's name to check the node against
+                - depth: The depth of the node (root=0)
         
     Returns:
         - True/False (bool)
     """
+
+    cursor = node["cursor"]
+    filename = node["filename"]
 
     if cursor.location.file and cursor.location.file.name == filename:
         return True
@@ -26,20 +32,27 @@ def is_node_in_this_file(cursor, filename, depth):
         return False
 
 
-def print_ast(cursor, filename, depth):
+def print_ast(node):
     """
     Prints the AST by recursively traversing the AST
 
     Arguments:
-        - cursor: The cursor pointing to a node
-        - filename: 
-            - The file's name to check if the node belongs to it
-            - Needed to ensure that only symbols belonging to the file gets parsed, not the included files' symbols
-        - depth: The depth of the node (root=0)
+        - node (dict):
+            - The node in the AST
+            - Keys:
+                - cursor: The cursor pointing to a node
+                - filename: 
+                    - The file's name to check if the node belongs to it
+                    - Needed to ensure that only symbols belonging to the file gets parsed, not the included files' symbols
+                - depth: The depth of the node (root=0)
     
     Returns:
         - None
     """
+
+    cursor = node["cursor"]
+    filename = node["filename"]
+    depth = node["depth"]
 
     # Check if the cursor has spelling (cursor.spelling -> not NoneType)
     if cursor.spelling:
@@ -55,20 +68,23 @@ def print_ast(cursor, filename, depth):
     for child in cursor.get_children():
         child_node = {"cursor": child, "filename": filename, "depth": depth + 1}
         # Check if the child belongs to the file
-        if is_node_in_this_file(**child_node):
-            print_ast(**child_node)
+        if is_node_in_this_file(child_node):
+            print_ast(child_node)
 
 
-def generate_parsed_info(cursor, filename, depth):
+def generate_parsed_info(node):
     """
     Generates parsed information by recursively traversing the AST
 
     Arguments:
-        - cursor: The cursor pointing to a node
-        - filename: 
-            - The file's name to check if the node belongs to it
-            - Needed to ensure that only symbols belonging to the file gets parsed, not the included files' symbols
-        - depth: The depth of the node (root=0)
+        - node (dict):
+            - The node in the AST
+            - Keys:
+                - cursor: The cursor pointing to a node
+                - filename: 
+                    - The file's name to check if the node belongs to it
+                    - Needed to ensure that only symbols belonging to the file gets parsed, not the included files' symbols
+                - depth: The depth of the node (root=0)
 
     Returns:
         - parsed_info (dict): 
@@ -77,6 +93,10 @@ def generate_parsed_info(cursor, filename, depth):
     """
 
     parsed_info = dict()
+
+    cursor = node["cursor"]
+    filename = node["filename"]
+    depth = node["depth"]
 
     # Check if the cursor has spelling (cursor.spelling -> not NoneType)
     if cursor.spelling:
@@ -101,8 +121,8 @@ def generate_parsed_info(cursor, filename, depth):
     for child in cursor.get_children():
         child_node = {"cursor": child, "filename": filename, "depth": depth + 1}
         # Check if the child belongs to the file
-        if is_node_in_this_file(**child_node):
-            child_parsed_info = generate_parsed_info(**child_node)
+        if is_node_in_this_file(child_node):
+            child_parsed_info = generate_parsed_info(child_node)
             # If both child and parent's info is not empty, add child's info to parent's members
             if child_parsed_info and parsed_info:
                 parsed_info["members"].append(child_parsed_info)
@@ -172,10 +192,10 @@ def parse_file(source, compilation_database_path=None):
     }
 
     # For testing purposes
-    # print_ast(**root_node)
+    # print_ast(root_node)
 
     # Dictionary containing parsed information of the source file
-    parsed_info = generate_parsed_info(**root_node)
+    parsed_info = generate_parsed_info(root_node)
 
     return parsed_info
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -151,11 +151,11 @@ def generate_parsed_info(node):
 
 def get_compilation_commands(compilation_database_path, filename):
     """
-    Returns the compilation commands extracted from the the compile command
+    Returns the compilation commands extracted from the compilation database
 
     Arguments:
         - compilation_database_path: The path to `compile_commands.json`
-        - filename: The file's name to get it's compilation commands
+        - filename: The file's name to get its compilation commands
 
     Returns:
         - compilation commands (list): The arguments passed to the compiler
@@ -185,10 +185,7 @@ def get_compilation_commands(compilation_database_path, filename):
         - nth element is the filename
     """
 
-    # Extracting argument list from the command's generator object
-    compilation_commands = list(compilation_commands[0].arguments)[1:-1]
-
-    return compilation_commands
+    return list(compilation_commands[0].arguments)[1:-1]
 
 
 def parse_file(source, compilation_database_path=None):
@@ -206,15 +203,10 @@ def parse_file(source, compilation_database_path=None):
     # Create a new index to start parsing
     index = clang.Index.create()
 
-    # Is this check needed?
-    if compilation_database_path is None:
-        # Default compiler argument
-        compilation_commands = ["-std=c++14"]
-    else:
-        # Get compiler arguments
-        compilation_commands = get_compilation_commands(
-            compilation_database_path=compilation_database_path, filename=source,
-        )
+    # Get compiler arguments
+    compilation_commands = get_compilation_commands(
+        compilation_database_path=compilation_database_path, filename=source,
+    )
 
     # Parse the given source code file by running clang and generating the AST before loading
     source_ast = index.parse(path=source, args=compilation_commands)

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -200,7 +200,7 @@ def parse_file(source, compilation_database_path=None):
         - compilation_database_path: The path to `compile_commands.json`
 
     Returns:
-        - parsed_info 
+        - parsed_info (dict)
     """
 
     # Create a new index to start parsing
@@ -229,10 +229,7 @@ def parse_file(source, compilation_database_path=None):
     # For testing purposes
     # print_ast(root_node)
 
-    # Dictionary containing parsed information of the source file
-    parsed_info = generate_parsed_info(root_node)
-
-    return parsed_info
+    return generate_parsed_info(root_node)
 
 
 def main():

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -126,12 +126,12 @@ def main():
             compilation_database_path=args.compilation_database_path, filename=source,
         )
 
-        tu = index.parse(path=source, args=compilation_commands)
+        source_ast = index.parse(path=source, args=compilation_commands)
 
-        # print_ast(cursor=tu.cursor, this_filename=tu.spelling, depth=0)
+        # print_ast(cursor=source_ast.cursor, this_filename=source_ast.spelling, depth=0)
 
         parsed_info = generate_parsed_info(
-            cursor=tu.cursor, this_filename=tu.spelling, depth=0
+            cursor=source_ast.cursor, this_filename=source_ast.spelling, depth=0
         )
 
         output_filepath = utils.get_json_output_path(

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -58,10 +58,6 @@ def generate_parsed_info(cursor, this_filename, depth):
     return parsed_info
 
 
-def create_index():
-    return clang.Index.create()
-
-
 def get_compilation_commands(compilation_database_path, filename):
     compilation_database = clang.CompilationDatabase.fromDirectory(
         buildDir=compilation_database_path
@@ -76,7 +72,7 @@ def main():
     for source in args.files:
         source = utils.get_realpath(path=source)
 
-        index = create_index()
+        index = clang.Index.create()
 
         compilation_commands = get_compilation_commands(
             compilation_database_path="/home/divyanshu/Projects/active/pcl/bindings/python",

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -9,7 +9,10 @@ def print_node(cursor, depth):
 
 
 def is_node_in_this_file(node, filename):
-    return node.location.file and node.location.file.name == filename
+    if node.location.file and node.location.file.name == filename:
+        return True
+    else:
+        return False
 
 
 def walk_and_print(cursor, this_filename, depth):

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -1,7 +1,8 @@
 import sys
 import clang.cindex as clang
 
-import utils
+from context import scripts
+import scripts.utils as utils
 
 
 def is_node_in_this_file(cursor, filename, depth):

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -55,11 +55,8 @@ def create_index():
     return clang.Index.create()
 
 
-def get_compilation_database(compilation_database_path):
-    return clang.CompilationDatabase.fromDirectory(buildDir=compilation_database_path)
-
-
-def get_compilation_commands(compilation_database, filename):
+def get_compilation_commands(compilation_database_path, filename):
+    compilation_database = clang.CompilationDatabase.fromDirectory(buildDir=compilation_database_path)
     compilation_commands = compilation_database.getCompileCommands(filename=filename)
     # extracting argument list from the command's generator object
     return list(compilation_commands[0].arguments)[1:-1]
@@ -72,9 +69,9 @@ def main():
 
         index = create_index()
 
-        compilation_database_path = utils.get_dirname(path="../compile_commands.json")
-        compilation_database = get_compilation_database(compilation_database_path=compilation_database_path)
-        compilation_commands = get_compilation_commands(compilation_database=compilation_database, filename=source)
+        compilation_commands = get_compilation_commands(
+            compilation_database_path="/home/divyanshu/Projects/active/pcl/bindings/python", filename=source
+        )
 
         tu = index.parse(path=source, args=compilation_commands)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -128,6 +128,8 @@ def parse_source(source, compilation_database_path=None):
 
     source_ast = index.parse(path=source, args=compilation_commands)
 
+    # print_ast(cursor=source_ast.cursor, this_filename=source_ast.spelling, depth=0)
+
     parsed_info = generate_parsed_info(
         cursor=source_ast.cursor, this_filename=source_ast.spelling, depth=0
     )
@@ -138,8 +140,6 @@ def main():
     args = utils.parse_arguments(script="parse")
     for source in args.files:
         source = utils.get_realpath(path=source)
-
-        # print_ast(cursor=source_ast.cursor, this_filename=source_ast.spelling, depth=0)
 
         parsed_info = parse_source(source, args.compilation_database_path)
 

--- a/bindings/python/scripts/parse.py
+++ b/bindings/python/scripts/parse.py
@@ -8,7 +8,7 @@ def print_node(cursor, depth):
     print("-" * depth, cursor.location.file, f"L{cursor.location.line} C{cursor.location.column}", cursor.kind.name, cursor.spelling)
 
 
-def node_in_this_file(node, filename):
+def is_node_in_this_file(node, filename):
     return node.location.file and node.location.file.name == filename
 
 
@@ -17,7 +17,7 @@ def walk_and_print(cursor, this_filename, depth):
         print_node(cursor=cursor, depth=depth)
 
     for child in cursor.get_children():
-        if node_in_this_file(node=child, filename=this_filename):
+        if is_node_in_this_file(node=child, filename=this_filename):
             walk_and_print(cursor=child, this_filename=this_filename, depth=depth + 1)
 
 
@@ -43,7 +43,7 @@ def generate_parsed_info(cursor, this_filename, depth):
         parsed_info["members"] = []
 
     for child in cursor.get_children():
-        if node_in_this_file(node=child, filename=this_filename):
+        if is_node_in_this_file(node=child, filename=this_filename):
             child_parsed_info = generate_parsed_info(cursor=child, this_filename=this_filename, depth=depth + 1,)
             if child_parsed_info and parsed_info:
                 parsed_info["members"].append(child_parsed_info)

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -12,10 +12,6 @@ def ensure_dir_exists(dir):
         os.makedirs(dir)
 
 
-def get_dirname(path):
-    return get_realpath(os.path.dirname(path))
-
-
 def get_json_output_path(source, output_dir):
     x_list = source.split("pcl/", 1)[-1]
     x_list = x_list.split("/")

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -21,18 +21,36 @@ def join_path(*args):
 
 
 def get_json_output_path(source, output_dir):
-    delimiter = "/" if "/" in source else "\\"
-    x_list = source.split(f"pcl{delimiter}", 1)[-1]
-    x_list = x_list.split(delimiter)
-    extra = ["pcl", "include"]
+    """
+    Returns json output path after manipulation of the source file's path
 
-    filename = x_list[-1].split(".")[0]
-    relative_dir = delimiter.join(x for x in x_list[:-1] if x not in extra)
+    Arguments:
+        - source: The source's file name
+        - output_dir: The output_directory to write the json output
+    
+    Returns:
+        - json_output_path: The json output's realpath
+    """
+    # pcl_path: contains the path as seen in the pcl directory
+    _, pcl_path = source.split(f"pcl{os.sep}", 1)
+
+    # relative_dir: contains the relative output path for the json file
+    # source_filename: contains the source's file name
+    relative_dir, source_filename = os.path.split(pcl_path)
+
+    # filename: contains the output json's file name
+    filename, _ = source_filename.split(".")
+    filename = f"{filename}.json"
+
+    # dir: final output path
     dir = join_path(output_dir, relative_dir)
 
+    # make the output directory if it doesn't exist
     ensure_dir_exists(dir)
 
-    return get_realpath(join_path(dir, f"{filename}.json"))
+    json_output_path = get_realpath(join_path(dir, filename))
+
+    return json_output_path
 
 
 def dump_json(filepath, info):

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -36,7 +36,7 @@ def dump_json(filepath, info):
 
 
 def parse_arguments(args, script):
-    if script == "parse.py":
+    if script == "parse":
         parser = argparse.ArgumentParser(description="C++ libclang parser")
         parser.add_argument("files", nargs="+", help="The source files to parse")
         return parser.parse_args(args)

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -31,6 +31,7 @@ def get_json_output_path(source, output_dir):
     Returns:
         - json_output_path: The json output's realpath
     """
+
     # pcl_path: contains the path as seen in the pcl directory
     _, pcl_path = source.split(f"pcl{os.sep}", 1)
 
@@ -59,6 +60,16 @@ def dump_json(filepath, info):
 
 
 def parse_arguments(script):
+    """
+    Returns parsed command line arguments for a given script
+
+    Arguments:
+        - script: The python script for which the custom command line arguments should be parsed
+
+    Return:
+        - args: Parsed command line arguments
+    """
+
     if script == "parse":
         parser = argparse.ArgumentParser(description="C++ libclang parser")
         parser.add_argument(
@@ -72,4 +83,6 @@ def parse_arguments(script):
             help="Output path for generated json",
         )
         parser.add_argument("files", nargs="+", help="The source files to parse")
-        return parser.parse_args()
+        args = parser.parse_args()
+
+        return args

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -16,18 +16,23 @@ def get_parent_directory(file):
     return os.path.dirname(os.path.dirname(file))
 
 
+def join_path(*args):
+    return os.path.join(*args)
+
+
 def get_json_output_path(source, output_dir):
-    x_list = source.split("pcl/", 1)[-1]
-    x_list = x_list.split("/")
+    delimiter = "/" if "/" in source else "\\"
+    x_list = source.split(f"pcl{delimiter}", 1)[-1]
+    x_list = x_list.split(delimiter)
     extra = ["pcl", "include"]
 
     filename = x_list[-1].split(".")[0]
-    relative_dir = "/".join(x for x in x_list[:-1] if x not in extra)
-    dir = os.path.join(output_dir, relative_dir)
+    relative_dir = delimiter.join(x for x in x_list[:-1] if x not in extra)
+    dir = join_path(output_dir, relative_dir)
 
     ensure_dir_exists(dir)
 
-    return get_realpath(f"{dir}/{filename}.json")
+    return get_realpath(join_path(dir, f"{filename}.json"))
 
 
 def dump_json(filepath, info):
@@ -50,4 +55,3 @@ def parse_arguments(args, script):
         )
         parser.add_argument("files", nargs="+", help="The source files to parse")
         return parser.parse_args(args)
-

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -26,7 +26,7 @@ def get_output_path(source, output_dir, split_from, extension):
 
     Arguments:
         - source: The source's file name
-        - output_dir: The output_directory to write the json output
+        - output_dir: The output directory to write the json output
         - split_from: The folder from which to split the path
         - extension: Output extension
     

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -20,7 +20,7 @@ def join_path(*args):
     return os.path.join(*args)
 
 
-def get_json_output_path(source, output_dir):
+def get_output_path(source, output_dir, split_from, extension):
     """
     Returns json output path after manipulation of the source file's path
 
@@ -33,15 +33,15 @@ def get_json_output_path(source, output_dir):
     """
 
     # pcl_path: contains the path as seen in the pcl directory
-    _, pcl_path = source.split(f"pcl{os.sep}", 1)
+    _, split_path = source.split(f"{split_from}{os.sep}", 1)
 
     # relative_dir: contains the relative output path for the json file
     # source_filename: contains the source's file name
-    relative_dir, source_filename = os.path.split(pcl_path)
+    relative_dir, source_filename = os.path.split(split_path)
 
     # filename: contains the output json's file name
     filename, _ = source_filename.split(".")
-    filename = f"{filename}.json"
+    filename = f"{filename}.{extension}"
 
     # dir: final output path
     dir = join_path(output_dir, relative_dir)
@@ -49,14 +49,26 @@ def get_json_output_path(source, output_dir):
     # make the output directory if it doesn't exist
     ensure_dir_exists(dir)
 
-    json_output_path = get_realpath(join_path(dir, filename))
+    output_path = get_realpath(join_path(dir, filename))
 
-    return json_output_path
+    return output_path
 
 
 def dump_json(filepath, info):
     with open(filepath, "w") as f:
         json.dump(info, f, indent=2)
+
+
+def read_json(filename):
+    with open(filename, "r") as f:
+        return json.load(f)
+
+
+def write_to_file(filename, linelist):
+    with open(filename, "w") as f:
+        for line in linelist:
+            f.writelines(line)
+            f.writelines("\n")
 
 
 def parse_arguments(script):
@@ -83,6 +95,18 @@ def parse_arguments(script):
             help="Output path for generated json",
         )
         parser.add_argument("files", nargs="+", help="The source files to parse")
-        args = parser.parse_args()
 
-        return args
+    if script == "generate":
+        parser = argparse.ArgumentParser(description="JSON to pybind11 generation")
+        parser.add_argument("files", nargs="+", help="JSON input")
+        parser.add_argument(
+            "--pybind11_output_path",
+            default=get_parent_directory(file=__file__),
+            help="Output path for generated cpp",
+        )
+
+    else:
+        args = None
+
+    args = parser.parse_args()
+    return args

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -12,6 +12,10 @@ def ensure_dir_exists(dir):
         os.makedirs(dir)
 
 
+def get_parent_directory(file):
+    return os.path.dirname(os.path.dirname(file))
+
+
 def get_json_output_path(source, output_dir):
     x_list = source.split("pcl/", 1)[-1]
     x_list = x_list.split("/")
@@ -34,6 +38,16 @@ def dump_json(filepath, info):
 def parse_arguments(args, script):
     if script == "parse":
         parser = argparse.ArgumentParser(description="C++ libclang parser")
+        parser.add_argument(
+            "--compilation_database_path",
+            default=get_parent_directory(file=__file__),
+            help="Path to compilation database (json)",
+        )
+        parser.add_argument(
+            "--json_output_path",
+            default=get_parent_directory(file=__file__),
+            help="Output path for generated json",
+        )
         parser.add_argument("files", nargs="+", help="The source files to parse")
         return parser.parse_args(args)
 

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -27,12 +27,14 @@ def get_output_path(source, output_dir, split_from, extension):
     Arguments:
         - source: The source's file name
         - output_dir: The output_directory to write the json output
+        - split_from: The folder from which to split the path
+        - extension: Output extension
     
     Returns:
-        - json_output_path: The json output's realpath
+        - output_path: The output's realpath
     """
 
-    # pcl_path: contains the path as seen in the pcl directory
+    # split_path: contains the path after splitting. For split_path = pcl, contains the path as seen in the pcl directory
     _, split_path = source.split(f"{split_from}{os.sep}", 1)
 
     # relative_dir: contains the relative output path for the json file
@@ -41,7 +43,7 @@ def get_output_path(source, output_dir, split_from, extension):
 
     # filename: contains the output json's file name
     filename, _ = source_filename.split(".")
-    filename = f"{filename}.{extension}"
+    filename = f"{filename}{extension}"
 
     # dir: final output path
     dir = join_path(output_dir, relative_dir)

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -40,7 +40,7 @@ def dump_json(filepath, info):
         json.dump(info, f, indent=2)
 
 
-def parse_arguments(args, script):
+def parse_arguments(script):
     if script == "parse":
         parser = argparse.ArgumentParser(description="C++ libclang parser")
         parser.add_argument(
@@ -54,4 +54,4 @@ def parse_arguments(args, script):
             help="Output path for generated json",
         )
         parser.add_argument("files", nargs="+", help="The source files to parse")
-        return parser.parse_args(args)
+        return parser.parse_args()

--- a/bindings/python/scripts/utils.py
+++ b/bindings/python/scripts/utils.py
@@ -1,0 +1,43 @@
+import os
+import json
+import argparse
+
+
+def get_realpath(path):
+    return os.path.realpath(path)
+
+
+def ensure_dir_exists(dir):
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+
+
+def get_dirname(path):
+    return get_realpath(os.path.dirname(path))
+
+
+def get_json_output_path(source, output_dir):
+    x_list = source.split("pcl/", 1)[-1]
+    x_list = x_list.split("/")
+    extra = ["pcl", "include"]
+
+    filename = x_list[-1].split(".")[0]
+    relative_dir = "/".join(x for x in x_list[:-1] if x not in extra)
+    dir = os.path.join(output_dir, relative_dir)
+
+    ensure_dir_exists(dir)
+
+    return get_realpath(f"{dir}/{filename}.json")
+
+
+def dump_json(filepath, info):
+    with open(filepath, "w") as f:
+        json.dump(info, f, indent=2)
+
+
+def parse_arguments(args, script):
+    if script == "parse.py":
+        parser = argparse.ArgumentParser(description="C++ libclang parser")
+        parser.add_argument("files", nargs="+", help="The source files to parse")
+        return parser.parse_args(args)
+


### PR DESCRIPTION
- move utitlity functions to `utils.py`
- remove terminal color print
- simplify `print_node`
- change `node_in_this_file` arg name
- remove `filter` and `lines` from functions: unused variables
- change `generate_parsed_info` return type to dict() from None
- changed `generate_parsed_info` operations from list to dict
- add `create_index`
- add `get_compilation_database`
- add `get_compile_commands`
- use real paths
- use`utils.py` functions
- use named arguments
- fix paths after moving to `scripts/`
- use named args